### PR TITLE
Changes for profiling, numa control and command line prefixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "logcabin"]
 	path = logcabin
 	url = https://github.com/logcabin/logcabin.git
+
+[submodule "pmu-tools"]
+	path = pmu-tools
+	url = http://github.com/anirajk/pmu-tools.git

--- a/apps/ClusterPerf.cc
+++ b/apps/ClusterPerf.cc
@@ -4788,8 +4788,10 @@ doWorkload(OpType type)
             if (!migration) {
                 RAMCLOUD_LOG(NOTICE, "Starting migration\n");
                 uint64_t endKeyHash = ~0lu;
-                if (migratePercentage < 100)
+                if (migratePercentage < 100) {
                     endKeyHash = endKeyHash / 100 * migratePercentage;
+		    cluster->splitTablet("data", endKeyHash+1);
+		}
                 migration.construct(cluster,
                                     dataTable,
                                     0,

--- a/scripts/cluster.py
+++ b/scripts/cluster.py
@@ -642,7 +642,7 @@ def run(
 #    client_hosts = [('rc52', '192.168.1.152', 52)]
     global numactl_command
     if numactl:
-        numactl_command = 'numactl --cpunodebind=0'
+        numactl_command = 'numactl --cpunodebind=0 --membind=0 '
     else:
         numactl_command = ''
     if profile:

--- a/scripts/cluster.py
+++ b/scripts/cluster.py
@@ -302,7 +302,8 @@ class Cluster(object):
                      disk=None,
                      port=server_port,
                      kill_on_exit=True,
-                     profile=None
+                     profile=None,
+                     profile_interval="100"
                      ):
         """Start a server on a node.
         @param host: (hostname, ip, id) tuple describing the node on which
@@ -364,9 +365,13 @@ class Cluster(object):
         stdout = open(log_prefix + '.out', 'w')
         stderr = open(log_prefix + '.err', 'w')
         if profile:
-            profile_command = ('%s -I 100 --socket 0 '
+            profile_command = ('%s -I %s --socket 0 '
+                               ' -o %s-%s.csv -x,'
                                ' --scale MB %s sleep 9999' %
                                (profile_bin,
+                                profile_interval,
+                                log_prefix,
+                                profile,
                                 ucevent_flags[profile]))
             print("profile cmd:",profile_command)
             profileout = open(log_prefix + '-profile.out', 'w')
@@ -603,11 +608,12 @@ def run(
         old_master_args='',        # Additional arguments to run on the
                                    # old master (e.g. total RAM).
         enable_logcabin=False,     # Do not enable logcabin.
-        valgrind=False,		   # Do not run under valgrind
-        valgrind_args='',	   # Additional arguments for valgrind
+        valgrind=False,		       # Do not run under valgrind
+        valgrind_args='',	       # Additional arguments for valgrind
         disjunct=False,            # Disjunct entities on a server
-        coordinator_host=None,
-        profile=None
+        coordinator_host=None,     # Co-ordinator machine
+        profile=None,              # Which ucevent to profile
+        profile_interval="1000"    # Profile interval in milliseconds
         ):
     """
     Start a coordinator and servers, as indicated by the arguments.  If a
@@ -672,7 +678,8 @@ def run(
             oldMaster = cluster.start_server(old_master_host,
                                              old_master_args,
                                              backup=False,
-                                             profile=profile)
+                                             profile=profile,
+                                             profile_interval=profile_interval)
             oldMaster.ignoreFailures = True
             masters_started += 1
             cluster.ensure_servers(timeout=60)
@@ -687,7 +694,8 @@ def run(
                 backups_started += 1
                 disk_args = disk1 if backup_disks_per_server == 1 else disk2
             cluster.start_server(host, args, backup=backup,
-                                 disk=disk_args, profile=profile)
+                                 disk=disk_args, profile=profile,
+                                 profile_interval=profile_interval)
             masters_started += 1
 
         if disjunct:

--- a/scripts/cluster.py
+++ b/scripts/cluster.py
@@ -203,7 +203,7 @@ class Cluster(object):
         self.next_client_id = 1
         self.masters_started = 0
         self.backups_started = 0
-        if config.hooks.other_hosts is not None:
+        if config.hooks.other_hosts:
             self.coordinator_host= config.hooks.other_hosts[0]
         else:
             self.coordinator_host= getHosts()[0]
@@ -652,7 +652,7 @@ def run(
             num_clients = 1
 
     if verbose:
-        if config.hooks.other_hosts is not None:
+        if not config.hooks.other_hosts:
             print('num_servers=(%d), available server hosts=(%d) defined in config.py'
                   % (num_servers, len(config.hooks.server_hosts)))
             print('num_clients=(%d), available other hosts=(%d) defined in config.py'
@@ -662,21 +662,20 @@ def run(
                   % (num_servers, len(getHosts())))
         print ('disjunct=', disjunct)
         print ('numactl=', numactl)
-
+	print ('cluster size=', len(getHosts()))
 # When disjunct=True, disjuncts Coordinator and Clients on Server nodes.
     if disjunct:
         if num_servers + num_clients + 1 > len(getHosts()):
             raise Exception('num_servers (%d)+num_clients (%d)+1(coord) exceeds the available hosts (%d)'
                             % (num_servers, num_clients, len(getHosts())))
     else:
-        if config.hooks.server_hosts is not None:
+        if config.hooks.server_hosts:
             max_servers = len(config.hooks.server_hosts)
         else:
             max_servers = len(getHosts())
         if num_servers > max_servers:
             raise Exception('num_servers (%d) exceeds the available hosts (%d)'
                             % (num_servers, max_servers))
-
     if not share_hosts and not client_hosts:
         if (len(getHosts()) - num_servers) < 1:
             raise Exception('Asked for %d servers without sharing hosts with %d '
@@ -703,7 +702,7 @@ def run(
         cluster.server_hosts = config.hooks.server_hosts
         cluster.other_hosts = config.hooks.other_hosts
         if not coordinator_host:
-            if cluster.other_hosts is not None:
+            if cluster.other_hosts:
                 coordinator_host = cluster.other_hosts[len(cluster.other_hosts)-1]
             else:
                 coordinator_host = cluster.hosts[len(cluster.hosts)-1]

--- a/scripts/cluster.py
+++ b/scripts/cluster.py
@@ -713,7 +713,7 @@ def run(
         coordinator = cluster.start_coordinator(coordinator_host,
                                                 coordinator_args)
         if disjunct:
-            if config.hooks.other_hosts is not None:
+            if config.hooks.other_hosts:
                 cluster.other_hosts.pop(0)
             cluster.hosts.pop(0)
 
@@ -726,7 +726,7 @@ def run(
             oldMaster.ignoreFailures = True
             masters_started += 1
             cluster.ensure_servers(timeout=60)
-        if config.server_hosts is not None:
+        if config.server_hosts:
             server_hosts = cluster.server_hosts[:num_servers]
         else:
             server_hosts = cluster.hosts[:num_servers]
@@ -745,7 +745,7 @@ def run(
             masters_started += 1
 
         if disjunct:
-            if config.server_hosts is not None:
+            if config.server_hosts:
                 cluster.server_hosts = cluster.server_hosts[num_servers:]
             else:
                 cluster.hosts = cluster.hosts[num_servers:]
@@ -767,17 +767,17 @@ def run(
             # don't do it unless necessary.
             if not client_hosts:
                 if disjunct:
-                    if cluster.other_hosts is not None:
+                    if cluster.other_hosts:
                         host_list = cluster.other_hosts[:]
                     else:
                         host_list = cluster.hosts[:]
                 else:
-                    if cluster.other_hosts is not None:
+                    if cluster.other_hosts:
                         host_list = cluster.other_hosts[:]
                     else:
                         host_list = cluster.hosts[num_servers:]
                     if share_hosts:
-                        if cluster.server_hosts is not None:
+                        if cluster.server_hosts:
                             host_list.extend(cluster.server_hosts[:num_servers])
                         else:
                             host_list.extend(cluster.hosts[:num_servers])

--- a/scripts/cluster.py
+++ b/scripts/cluster.py
@@ -368,15 +368,28 @@ class Cluster(object):
         # Adding redirection for stdout and stderr.
         stdout = open(log_prefix + '.out', 'w')
         stderr = open(log_prefix + '.err', 'w')
+        global numactl_command
         if profile:
-            profile_command = ('%s -I %s --socket 0 '
-                               ' -o %s-%s.csv -x,'
-                               ' --scale MB %s sleep 9999' %
-                               (profile_bin,
-                                profile_interval,
-                                log_prefix,
-                                profile,
-                                ucevent_flags[profile]))
+            profile_command = None
+            if numactl_command == '':
+                 profile_command = ('%s -I %s'
+                                   ' -o %s-%s.csv -x,'
+                                   ' --scale MB %s sleep 9999' %
+                                   (profile_bin,
+                                   profile_interval,
+                                   log_prefix,
+                                   profile,
+                                   ucevent_flags[profile]))
+           
+            else: 
+                profile_command = ('%s -I %s --socket 0 '
+                                   ' -o %s-%s.csv -x,'
+                                   ' --scale MB %s sleep 9999' %
+                                   (profile_bin,
+                                   profile_interval,
+                                   log_prefix,
+                                   profile,
+                                   ucevent_flags[profile]))
             print("profile cmd:",profile_command)
             profileout = open(log_prefix + '-profile.out', 'w')
             profilerr = open(log_prefix + '-profile.err', 'w')
@@ -648,6 +661,7 @@ def run(
             print('num_servers=(%d), available hosts=(%d) defined in config.py'
                   % (num_servers, len(getHosts())))
         print ('disjunct=', disjunct)
+        print ('numactl=', numactl)
 
 # When disjunct=True, disjuncts Coordinator and Clients on Server nodes.
     if disjunct:

--- a/scripts/clusterperf.py
+++ b/scripts/clusterperf.py
@@ -257,7 +257,8 @@ def run_test(
         'transport':   options.transport,
         'replicas':    options.replicas,
         'disjunct':    options.disjunct,
-        'verbose':     options.verbose
+        'verbose':     options.verbose,
+        'profile':     options.profile
     }
     client_args = {}
     # Provide a default value for num_servers here.  This is better
@@ -716,6 +717,10 @@ def calculatePerClientTarget(workload, clients, percentage):
     return int(peak * (percentage / 100.0) / int(clients))
 
 def migrateLoaded(name, options, cluster_args, client_args):
+    if "profile" in cluster_args.keys():
+        print("cluster args:",cluster_args)
+        print("client args:", client_args)
+        return
     if not options.extract:
         clients = options.num_clients
         servers = options.num_servers # len(getHosts()) - clients - 1
@@ -938,6 +943,10 @@ if __name__ == '__main__':
             action='store_true', default=False, dest='fullSamples',
             help='Run with alternate sample format that includes sample '
                  'timestamps along with their durations.')
+    parser.add_option('--profile', type=str, dest='profile',
+            default=None, metavar='membw/ddiobw/pciebw',
+            help='Profile Memory B/W, DDIO induced LLC misses'
+                 ' or PCIE traffic using ucevent tool')       
     (options, args) = parser.parse_args()
 
     if options.parse:

--- a/scripts/clusterperf.py
+++ b/scripts/clusterperf.py
@@ -258,7 +258,8 @@ def run_test(
         'replicas':    options.replicas,
         'disjunct':    options.disjunct,
         'verbose':     options.verbose,
-        'profile':     options.profile
+        'profile':     options.profile,
+        'profile_interval': options.profile_interval
     }
     client_args = {}
     # Provide a default value for num_servers here.  This is better
@@ -717,10 +718,6 @@ def calculatePerClientTarget(workload, clients, percentage):
     return int(peak * (percentage / 100.0) / int(clients))
 
 def migrateLoaded(name, options, cluster_args, client_args):
-    if "profile" in cluster_args.keys():
-        print("cluster args:",cluster_args)
-        print("client args:", client_args)
-        return
     if not options.extract:
         clients = options.num_clients
         servers = options.num_servers # len(getHosts()) - clients - 1
@@ -946,7 +943,10 @@ if __name__ == '__main__':
     parser.add_option('--profile', type=str, dest='profile',
             default=None, metavar='membw/ddiobw/pciebw',
             help='Profile Memory B/W, DDIO induced LLC misses'
-                 ' or PCIE traffic using ucevent tool')       
+                 ' or PCIE traffic using ucevent tool')
+    parser.add_option('--profile_interval', type=str, dest='profile_interval',
+            default="100", metavar="MSECS",
+            help='perf sample interval for ucevent tool in milliseconds')    
     (options, args) = parser.parse_args()
 
     if options.parse:

--- a/scripts/clusterperf.py
+++ b/scripts/clusterperf.py
@@ -260,7 +260,8 @@ def run_test(
         'verbose':     options.verbose,
         'profile':     options.profile,
         'profile_interval': options.profile_interval,
-        'numactl':     options.numactl
+        'numactl':     options.numactl,
+        'prefix_bin':  options.prefix_bin
     }
     client_args = {}
     # Provide a default value for num_servers here.  This is better
@@ -950,6 +951,10 @@ if __name__ == '__main__':
             help='perf sample interval for ucevent tool in milliseconds')    
     parser.add_option('--numactl', action='store_true', default=False,
             help='Enable numactl and bind to first socket (cpu0)')
+    parser.add_option('--prefix_bin', type=str, dest='prefix_bin',
+            default='', metavar='PREFIX',
+            help='command line prefix for all binaries')
+
     (options, args) = parser.parse_args()
 
     if options.parse:

--- a/scripts/clusterperf.py
+++ b/scripts/clusterperf.py
@@ -259,7 +259,8 @@ def run_test(
         'disjunct':    options.disjunct,
         'verbose':     options.verbose,
         'profile':     options.profile,
-        'profile_interval': options.profile_interval
+        'profile_interval': options.profile_interval,
+        'numactl':     options.numactl
     }
     client_args = {}
     # Provide a default value for num_servers here.  This is better
@@ -947,6 +948,8 @@ if __name__ == '__main__':
     parser.add_option('--profile_interval', type=str, dest='profile_interval',
             default="100", metavar="MSECS",
             help='perf sample interval for ucevent tool in milliseconds')    
+    parser.add_option('--numactl', action='store_true', default=False,
+            help='Enable numactl and bind to first socket (cpu0)')
     (options, args) = parser.parse_args()
 
     if options.parse:

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -84,7 +84,8 @@ class Sandbox(object):
         @return: If bg is True then a Process corresponding to the command
                  which was run, otherwise None.
         """
-        checkHost(host)
+        if config.hooks.server_hosts is None:
+            checkHost(host)
         if bg:
             sonce = ''.join([chr(random.choice(range(ord('a'), ord('z'))))
                              for c in range(8)])

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -26,9 +26,9 @@ import re
 import subprocess
 
 __all__ = ['coordinator_port', 'default_disk1','default_disk2', 'git_branch',
-           'git_ref', 'git_diff', 'hosts','obj_dir', 'obj_path',
-           'local_scripts_path', 'second_backup_port', 'server_port',
-           'top_path']
+           'git_ref', 'git_diff', 'hosts', 'server_hosts', 'other_hosts',
+           'obj_dir', 'obj_path', 'local_scripts_path',
+           'second_backup_port', 'server_port', 'top_path']
 
 # git_branch is the name of the current git branch, which is used
 # for purposes such as computing objDir.
@@ -105,7 +105,8 @@ default_disk2 = '-f /dev/sda2,/dev/sdb2'
 # List of machines available to use as servers or clients; see
 # common.getHosts() for more information on how to set this variable.
 hosts = None
-
+server_hosts = None
+other_hosts = None
 class NoOpClusterHooks:
     def __init__(self):
         pass

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -107,6 +107,7 @@ default_disk2 = '-f /dev/sda2,/dev/sdb2'
 hosts = None
 server_hosts = None
 other_hosts = None
+
 class NoOpClusterHooks:
     def __init__(self):
         pass

--- a/scripts/emulabconfig.py
+++ b/scripts/emulabconfig.py
@@ -129,8 +129,6 @@ class EmulabClusterHooks:
         self.other_hosts = getHosts(othersOnly=True)
         self.makeflags = makeflags
         self.parallel = self.cmd_exists("pdsh")
-        print("numactl:",self.cmd_exists("numactl",server=self.hosts[0][0]))
-        print("junkcmd:",self.cmd_exists("junkcmd",server=self.hosts[0][0]))
         for host in self.hosts:
             if not self.cmd_exists("numactl",server=host[0]):
                 log("WARNING: numactl not installed. install numactl"

--- a/scripts/emulabconfig.py
+++ b/scripts/emulabconfig.py
@@ -55,6 +55,7 @@ def getHosts(serversOnly=False, othersOnly=False):
                 if host.tag.endswith('host'):
                     serverList.append((host.attrib['name'], host.attrib['ipv4'], nodeId))
                     nodeId += 1
+    #for mixed profiles with server-* and client-* nodes
     if serversOnly:
         serverList = [server for server in serverList if server[0].startswith("server")]
     if othersOnly:
@@ -136,8 +137,8 @@ class EmulabClusterHooks:
         self.parallel = self.cmd_exists("pdsh")
         for host in self.hosts:
             if not self.cmd_exists("numactl",server=host[0]):
-                log("WARNING: numactl not installed. install numactl"
-                    " and provide --numactl flag in clusterperf for multi socket machines")
+                log("WARNING: numactl not installed on %s. install numactl"
+                    " and provide --numactl flag for multisocket machines" % host[0])
         if not self.parallel:
             log("NOTICE: Remote commands could be faster if you install and configure pdsh")
             self.remote_func = self.serial

--- a/scripts/emulabconfig.py
+++ b/scripts/emulabconfig.py
@@ -115,11 +115,11 @@ else:
 
 # Command-line argument specifying where the server should store the segment
 # replicas when one device is used.
-default_disk1 = '-f /dev/sda2'
+default_disk1 = '-f /dev/sda4'
 
 # Command-line argument specifying where the server should store the segment
 # replicas when two devices are used.
-default_disk2 = '-f /dev/sda2,/dev/sda3'
+default_disk2 = '-f /dev/sda4,/dev/sdb'
 
 class EmulabClusterHooks:
     def __init__(self, makeflags=''):

--- a/scripts/emulabconfig.py
+++ b/scripts/emulabconfig.py
@@ -8,7 +8,7 @@ ssh access. Check https://www.cloudlab.us/ssh-keys.php if you didn't export keys
 Sample localconfig.py 
 from emulabconfig import *
 hooks = EmulabClusterHooks(makeflags='-j12 DEBUG=no');
-# EmulabClusterHooks(makeflags='-j12 DPDK=yes DPDK_DIR=/local/RAMCloud/deps/dpdk-16.07')
+# EmulabClusterHooks(makeflags='-j12 DEBUG=no DPDK=yes DPDK_DIR=/local/RAMCloud/deps/dpdk-16.07')
 # builds for DPDK
 hosts = getHosts()
 

--- a/scripts/emulabconfig.py
+++ b/scripts/emulabconfig.py
@@ -21,7 +21,7 @@ import re
 import socket
 import xml.etree.ElementTree as ET
 
-__all__ = ['getHosts', 'local_scripts_path', 'top_path', 'obj_path',
+__all__ = ['getHosts', 'checkHost', 'local_scripts_path', 'top_path', 'obj_path',
            'default_disk1', 'default_disk2', 'EmulabClusterHooks', 'log'] 
 
 hostname = socket.gethostname()
@@ -62,7 +62,12 @@ def getHosts(serversOnly=False, othersOnly=False):
         serverList = [client for client in serverList if client[0].startswith("client")]
     return serverList
 
-    
+def checkHost(host):
+    serverList = getHosts()
+    for server in serverList:
+        if host == server[0]:
+            return True
+    raise Exception("Attempted host %s not found in localconfig" % host)
 
 def ssh(server, cmd, checked=True):
     """ Runs command on a remote machine over ssh.""" 

--- a/src/AbstractLog.h
+++ b/src/AbstractLog.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2009-2016 Stanford University
+/* Copyright (c) 2009-2017 Stanford University
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -16,6 +16,7 @@
 #ifndef RAMCLOUD_ABSTRACTLOG_H
 #define RAMCLOUD_ABSTRACTLOG_H
 
+#include <atomic>
 #include <stdint.h>
 #include <unordered_map>
 #include <vector>
@@ -250,7 +251,7 @@ class AbstractLog {
     // Total amount of log space occupied by long-term data such as
     // objects. Excludes data that can eventually be cleaned, such
     // as tombstones.
-    uint64_t totalLiveBytes;
+    std::atomic<uint64_t> totalLiveBytes;
 
     // Largest value of totalLiveBytes that is "safe" (i.e. the cleaner
     // can always make progress).

--- a/src/MasterService.cc
+++ b/src/MasterService.cc
@@ -1093,7 +1093,7 @@ MasterService::migrateTablet(const WireFormat::MigrateTablet::Request* reqHdr,
     bool found = tabletManager.getTablet(tableId, firstKeyHash, lastKeyHash, 0);
     if (!found) {
         LOG(WARNING, "Migration request for tablet this master does not own: "
-            "tablet [0x%lx,0x%lx] in tableId %lu", firstKeyHash, lastKeyHash,
+            "tablet [0x%lx,0x%lx] in tableId %lu. Did you split the tablets correctly ?", firstKeyHash, lastKeyHash,
             tableId);
         respHdr->common.status = STATUS_UNKNOWN_TABLET;
         return;
@@ -2392,7 +2392,7 @@ MasterService::splitMasterTablet(
     bool split = tabletManager.splitTablet(reqHdr->tableId,
             reqHdr->splitKeyHash);
     if (split) {
-        LOG(NOTICE, "In table '%lu' I split the tablet at key %lu ",
+        LOG(NOTICE, "In table '%lu' I split the tablet at key 0x%lx ",
                 reqHdr->tableId, reqHdr->splitKeyHash);
     } else {
         LOG(WARNING, "Could not split table %lu at key hash %lu:"


### PR DESCRIPTION
`--prefix_bin=sudo` executes binaries as sudo for experiments on DPDK transport.
`--profile=P` profiles using pmu-tools and collects their logs
`--numactl` binds cpu and memory to numa node-0 for multi socket machines
alwaysclean and dpdk arguments in addition to makeflags for customising localconfig (provided sample config as comments in emulab config)